### PR TITLE
version-bump-0.1.3

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ permalink: pretty
 source: docs
 baseurl: "/style-guide"
 
-version: 0.1.1
+version: 0.1.3
 
 port: 8888
 host: localhost

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daptiv-style-guide",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "Common styles and pattern library for Daptiv",
   "author": "Changepoint",
   "homepage": "https://daptiv.github.com/style-guide",


### PR DESCRIPTION
version bump to match next tag: 0.1.3
### After Merge
- [ ] [site](https://daptiv.github.io/style-guide) is updated
