### PR TITLE
update-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Common styles and pattern library for daptiv. You can view the style guide [here
 
 ## Install
 
-This project can be included using [bower](http://bower.io/) by creating an entry in your bower.json file with the url `https://github.com/daptiv/style-guide.git#VERSION` where VERSION is the version you care to use.
+Style-guide is available as [bower](http://bower.io/) package. This can be included by creating an entry in your bower.json file with the url `https://github.com/daptiv/style-guide.git#VERSION` where VERSION is the version you care to use.
 
 ## Running Locally
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
+[![octocat style](http://matthias.vallentin.net/blog/2012/12/octocat.jpeg)](https://daptiv.github.io/style-guide/)
+
 # Style Guide
-Common styles and pattern library for daptiv. You can view the style guide [here](https://daptiv.github.io/style-guide).
+Common styles and pattern library for daptiv. You can view the style guide [here](https://daptiv.github.io/style-guide/).
 
-# Install
+## Install
 
-Use the style-guide.less / style-guide.css file in your project.
+This project can be included using [bower](http://bower.io/) by creating an entry in your bower.json file with the url `https://github.com/daptiv/style-guide.git#VERSION` where VERSION is the version you care to use.
 
-# Update Version
+## Running Locally
 
-use `npm run update-version -- version=[newversion]` to update the version for package.json and \_config.yml
+* First install dependencies `npm install && bundle install`
+* For development, run: `grunt serve` this starts a local web server and a watch task.
+* In a browser, go to: `http//localhost:8888/style-guide` this will automatically refresh when changes are made.
 
-# Linting
+## Pull requests
 
-We use [hound](https://houndci.com) to run linting on our scss files.
+We use [pullquester](https://github.com/daptiv/pullquester) to create pull requests. It provides all the important information for requests and instructions on how to publish changes after the pull request is complete.
 
-#Running Locally
+## Publishing
 
-* First run `npm install`
-* Run `grunt serve` to deploy changes to the local web server. (This also adds a 'watch' so that subsequent changes are deployed automatically.)
-* Go to: `http//localhost:8888/style-guide`
+To publish the site:
+
+1. Pull latest master: `git checkout master && git pull`
+2. Run `npm version patch`
+
+Some versions of npm do not correctly call the `postversion` script. If you run npm version and all it outputs to the command line is a version number, you are running one of the affected versions of npm.
+
+In the event that the `postversion` script is not run, simply run `npm run-script postversion`
+
+Running `npm version` will:
+
+1. Update [package.json's](package.json) version according to the rule provided. (most of the time by incrementing patch number)
+2. Commit the change to package.json and tag the resulting commit with the same version
+3. Push the commit and tag up to github.
+4. Run `grunt publish` which will, in turn:
+    1. Build the site
+    2. Publish the newly built site to the `gh-pages` branch
+    3. Push the `gh-pages` branch to github, updating the [style guide site](https://daptiv.github.io/style-guide/)


### PR DESCRIPTION
### Review
 - [x] @boskya
 - [x] @park9140


### After Merge


run:

```
git checkout master
git pull
npm version patch
```

### note

If npm version is `2.13` or later npm version will likely fail to run postversion script, leaving you with pending commits in your repo.

If this is the case, run `npm run-script postversion` to finish the process.