### PR TITLE
Fix Daptiv Logo Size Medium Dimensions

### DIFF
--- a/styles/_identity.scss
+++ b/styles/_identity.scss
@@ -16,7 +16,7 @@
     }
 
     &.size-medium {
-        background-size: 82px 38px;
+        background-size: 109px 38px;
         display: inline-block;
         height: 38px;
         width: 109px;


### PR DESCRIPTION
#### Description
Fixed the size-medium style to have the correct width for the background-size so it matches the expected width of 109px.

#### Code Review
- [x] @park9140 