### PR TITLE
npmrc-and-contributors-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ docs/fonts/
 .sass-cache/
 Gemfile.lock
 
-.npmrc
 .idea/.name
 
 .idea/jsLibraryMappings.xml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry = https://registry.npmjs.org/
+always-auth = false

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+boskya (https://www.npmjs.com/~boskya)
+jtrinklein (https://www.npmjs.com/~jtrinklein)
+dledesma (https://www.npmjs.com/~dledesma)

--- a/README.md
+++ b/README.md
@@ -26,16 +26,15 @@ We use [pullquester](https://github.com/daptiv/pullquester) to create pull reque
 1. Pull latest master: `git checkout master && git pull`
 2. Run `npm version patch`
 
-### The npm package
+### The npm package:
 
-#### Pre-requisties
-Before publishing you need to have a [npm account](https://www.npmjs.com/signup). Once you have an account, please ask one of the owners (listed in owners.md file) to add you as colloborator. 
+**IMPORTANT NOTE:** Before publishing you need to have a [npm account](https://www.npmjs.com/signup). Once you have an account, please create a pull request adding yourself to the [CONTRIBUTORS](CONTRIBUTORS.md) file referencing one of the [owners](owners.md) to review.
 
 1. Pull latest master: `git checkout master && git pull`
 2. log in to npm `npm login`
 3. publish the package `npm publish`
 
-### More Information 
+### More Information
 
 Some versions of npm do not correctly call the `postversion` script. If you run npm version and all it outputs to the command line is a version number, you are running one of the affected versions of npm.
 


### PR DESCRIPTION
### Review
 - [x] @boskya


### After Merge


run:

```
git checkout master
git pull
npm version patch
npm publish
```

### note

If npm version is `2.13` or later npm version will likely fail to run postversion script, leaving you with pending commits in your repo.

If this is the case, run `npm run-script postversion` to finish the process.